### PR TITLE
config.sample.json: Add wuiOpenHost

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -17,6 +17,7 @@
   "wuiTlsCaPath": null,
   "wuiOpenServer": true,
   "wuiOpenPort": 20772,
+  "wuiOpenHost": "0.0.0.0",
   "wuiXFF": false,
   "wuiDLNAServerEnabled": false,
   "wuiMdnsAdvertisement": true,


### PR DESCRIPTION
wuiOpenHostを設定しないと外部のマシンからChinachuにアクセスできなかったので追加しました．
意図的なものであれば，スルーお願いします．